### PR TITLE
Ressurect the extension by using newer API for getting databases

### DIFF
--- a/lib/index-injected.js
+++ b/lib/index-injected.js
@@ -5,24 +5,28 @@
 var PouchDB = global.PouchDB;
 
 if (PouchDB) {
-  PouchDB = PouchDB.defaults({});
+    PouchDB = PouchDB.defaults({});
 
-  PouchDB.allDbs = function () {
-    var prefix = typeof PouchDB.prefix === "undefined" ? "_pouch_" : PouchDB.prefix;
-    return getIDBDatabaseNames().then(function (names) {
-      return names.filter(function (name) {
-        return name.indexOf(prefix) === 0;
-      }).map(function (name) {
-        return name.substr(prefix.length);
-      }).filter(function (name) {
-        return (
-          ["_checkModernIdb", "pouch__all_dbs__"].indexOf(name) === -1 &&
-          name.indexOf("-mrview-") === -1 &&
-          name.indexOf("-session-") === -1
-        );
-      });
-    });
-  };
+    PouchDB.allDbs = function () {
+        var prefix = typeof PouchDB.prefix === "undefined" ? "_pouch_" : PouchDB.prefix;
+        return getIDBDatabaseNames().then(function (databasesMap) {
+            let names = databasesMap.map((databaseEntry) => {
+                return databaseEntry.name;
+            });
+
+            return names.filter(function (name) {
+                return name.indexOf(prefix) === 0;
+            }).map(function (name) {
+                return name.substr(prefix.length);
+            }).filter(function (name) {
+                return (
+                    ["_checkModernIdb", "pouch__all_dbs__"].indexOf(name) === -1 &&
+                    name.indexOf("-mrview-") === -1 &&
+                    name.indexOf("-session-") === -1
+                );
+            });
+        });
+    };
 }
 
 var req2resp = require("./req2resp.js")(PouchDB);
@@ -33,16 +37,14 @@ global.addEventListener("message", rpc.onMessage);
 rpc.serve("req2resp", req2resp);
 
 var getIDBDatabaseNames;
-if (global.indexedDB.webkitGetDatabaseNames) {
-  getIDBDatabaseNames = function () {
-    //Promisify webkitGetDatabaseNames()
-    return new global.Promise(function (resolve, reject) {
-      var req = global.indexedDB.webkitGetDatabaseNames().onsuccess = function () {
-        resolve(Array.prototype.slice.call(this.result));
-      };
-    });
-  };
+// supported on every browser except firefox at the time of writing
+// https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/databases
+if (global.indexedDB.databases) {
+    getIDBDatabaseNames = function () {
+        return global.indexedDB.databases();
+    };
 } else {
-  //In Firefox, ask the add-on to provide the idb db names
-  getIDBDatabaseNames = rpc.call.bind(rpc, "main", "getIDBDatabaseNames");
+    // I don't know how the fallback worked before but it probably no longer work on those browsers
+    //In Firefox, ask the add-on to provide the idb db names
+    getIDBDatabaseNames = rpc.call.bind(rpc, "main", "getIDBDatabaseNames");
 }


### PR DESCRIPTION
@marten-de-vries 
The chrome extension [stopped working in chromium >=60](https://github.com/pouchdb/pouchdb-fauxton-chrome-extension/issues/17) (it worked but getting databases was not working, which made the extension not really useful).
This happenned because of the use of a deprecated API.
However since ~2018, a [new API](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/databases) solving the original issue is now widely supported.

This PR make use of the new API and should work, I have tested it locally successfully.
I hope the original developpers can take a look at this.

minor notes:
I couldn't find documentation for the return type of the old API but anyway: The new API natively return a promise so wrapping it is no longer needed.
Moreover, it return a dictionnary containing db name and version. Hence I use a map to only return (filter) a vector of names, matching old behaviour.

update:
I can get the right node/npm version by using:
[nvm](https://github.com/nvm-sh/nvm) install v0.10.10
nvm use v0.10.10

but now after downloading dependencies, I get an npm error:
```
...
npm http GET https://registry.npmjs.org/phantomjs
npm http GET https://registry.npmjs.org/grunt-contrib-watch
npm http GET https://registry.npmjs.org/async
npm http GET https://registry.npmjs.org/grunt
npm http GET https://registry.npmjs.org/grunt-chmod
npm http GET https://registry.npmjs.org/couchapp
npm http GET https://registry.npmjs.org/grunt-cli
npm http GET https://registry.npmjs.org/grunt-contrib-copy
npm http GET https://registry.npmjs.org/grunt-contrib-concat
npm http GET https://registry.npmjs.org/grunt-contrib-cssmin
npm http GET https://registry.npmjs.org/grunt-contrib-clean
npm http GET https://registry.npmjs.org/grunt-contrib-jshint
npm ERR! Error: CERT_UNTRUSTED
npm ERR!     at SecurePair.<anonymous> (tls.js:1346:32)
npm ERR!     at SecurePair.EventEmitter.emit (events.js:92:17)
npm ERR!     at SecurePair.maybeInitFinished (tls.js:959:10)
npm ERR!     at CleartextStream.read [as _read] (tls.js:463:15)
npm ERR!     at CleartextStream.Readable.read (_stream_readable.js:320:10)
npm ERR!     at EncryptedStream.write [as _write] (tls.js:366:25)
npm ERR!     at doWrite (_stream_writable.js:219:10)
npm ERR!     at writeOrBuffer (_stream_writable.js:209:5)
npm ERR!     at EncryptedStream.Writable.write (_stream_writable.js:180:11)
npm ERR!     at write (_stream_readable.js:573:24)
npm ERR!     at flow (_stream_readable.js:582:7)
npm ERR!     at Socket.pipeOnReadable (_stream_readable.js:614:5)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
```
(I have npm version 1.2.25 set by nvm)

update:
hmm apparently HTTPS can be bypassed:
https://stackoverflow.com/a/22526046/12607379
by setting
npm config set strict-ssl false

there is only one remaining error:
```
npm ERR! Error: No compatible version found: grunt-chmod@'^1.0.3'
npm ERR! Valid install targets:
npm ERR! ["1.0.0","1.0.1","1.0.2","1.0.3","1.1.0","1.1.1"]
npm ERR!     at installTargetsError (/home/stephane/.nvm/v0.10.10/lib/node_modules/npm/lib/cache.js:709:10)
npm ERR!     at /home/stephane/.nvm/v0.10.10/lib/node_modules/npm/lib/cache.js:631:10
npm ERR!     at saved (/home/stephane/.nvm/v0.10.10/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:138:7)
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>

npm ERR! System Linux 5.14.13-1-MANJARO
npm ERR! command "/home/stephane/.nvm/v0.10.10/bin/node" "/home/stephane/.nvm/v0.10.10/bin/npm" "install"
npm ERR! cwd /home/stephane/WebstormProjects/pouchdb-fauxton-base
npm ERR! node -v v0.10.10
npm ERR! npm -v 1.2.25
```

so I removed any ^ charachter found in package.json (unsure how correct is that "fix"..)
and I had to remove ~ from the package async.
and this cause more dependency errors...
I don't know how to fix the dependencies, the build should be reproducible but it isn't even when removing version ranges.

There is a version of the extension online:
https://ma.rtendevri.es/fauxton/

I have no idea how to build the project, maybe that I don't have the exactly right node and npm version, if so what are them??

to be clear the issue is in building [fauxton-base](https://github.com/pouchdb/pouchdb-fauxton-base) 

update:
I did fix the dependencies by updating them all and switching back to recent node/npm and deleting phantomjs dependency (what was it used for?)
however I now have a runtime error
```
> fauxton@1.0.3 postinstall
> grunt release

Running "clean:release" (clean) task
>> 0 paths cleaned.

Running "clean:watch" (clean) task
>> 0 paths cleaned.

Running "get_deps:default" (get_deps) task
Fetching external dependencies
0 remote dependencies
0 local dependencies

Running "gen_load_addons:default" (gen_load_addons) task

Running "gen_initialize:release" (gen_initialize) task

Running "jshint:all" (jshint) task
>> 201 files lint free.

Running "shell:build-jsx" (shell) task
built Module("activetasks/tests/activetasks.componentsSpec.react")
built Module("auth/components.react")
built Module("auth/test/auth.componentsSpec.react")
built Module("cluster/cluster.react")
built Module("cluster/tests/clusterSpec.react")
built Module("activetasks/components.react")
built Module("compaction/components.react")
built Module("components/react-components.react")
built Module("compaction/tests/componentsSpec.react")
built Module("components/tests/beautifySpec.react")
built Module("components/tests/codeEditorPanelSpec.react")
built Module("components/tests/codeEditorSpec.react")
built Module("components/tests/confirmButtonSpec.react")
built Module("components/tests/docSpec.react")
built Module("components/tests/headerTogglebuttonSpec.react")
built Module("components/tests/paddedBorderedBoxSpec.react")
built Module("components/tests/zenModeSpec.react")
built Module("components/tests/styledSelectSpec.react")
built Module("databases/components.react")
built Module("cors/components.react")
built Module("cors/tests/componentsSpec.react")
built Module("databases/tests/componentsSpec.react")
built Module("documents/changes/components.react")
built Module("documents/designdocinfo/components.react")
built Module("documents/changes/tests/changes.componentsSpec.react")
built Module("documents/index-editor/components.react")
built Module("documents/index-editor/tests/viewIndex.componentsSpec.react")
built Module("documents/header/header.react")
built Module("documents/header/tests/headerSpec.react")
built Module("documents/index-results/tests/index-results.componentsSpec.react")
built Module("documents/index-results/index-results.components.react")
built Module("documents/mango/mango.components.react")
built Module("documents/mango/tests/mango.componentsSpec.react")
built Module("documents/pagination/tests/pagination.componentSpec.react")
built Module("documents/pagination/pagination.react")
built Module("documents/queryoptions/queryoptions.react")
built Module("documents/queryoptions/tests/queryoptions.componentsSpec.react")
built Module("documents/sidebar/sidebar.react")
built Module("fauxton/components.react")
built Module("fauxton/navigation/components.react")
Error while reading module fauxton/tests/componentsSpec.react:
Error: Parse Error: Line 145: Unexpected string
    at throwError (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2338:21)
    at throwUnexpected (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2378:13)
    at parseXJSIdentifier (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5769:13)
    at parseXJSAttributeName (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5814:16)
    at parseXJSAttribute (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5901:16)
    at parseXJSOpeningElement (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5958:29)
    at parseXJSElement (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5983:26)
    at parsePrimaryExpression (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2906:20)
    at parseLeftHandSideExpressionAllowCall (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2990:61)
    at parsePostfixExpression (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:3030:20)
From previous event:
    at buildP (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:167:16)
    at ModuleReader.processOutputP (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:221:16)
    at ModuleReader.buildModuleP (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:132:23)
    at ModuleReader.wrapper [as buildModuleP] (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/util.js:53:31)
    at /home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:126:27
From previous event:
    at ModuleReader.<anonymous> (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:97:38)
    at ModuleReader.wrapper [as readModuleP] (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/util.js:53:31)
    at Array.map (<anonymous>)
    at /home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:231:32
From previous event:
    at rebuild (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/commoner.js:135:14)
    at processTicksAndRejections (node:internal/process/task_queues:75:11)
Error: Parse Error: Line 145: Unexpected string
    at throwError (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2338:21)
    at throwUnexpected (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2378:13)
    at parseXJSIdentifier (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5769:13)
    at parseXJSAttributeName (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5814:16)
    at parseXJSAttribute (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5901:16)
    at parseXJSOpeningElement (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5958:29)
    at parseXJSElement (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:5983:26)
    at parsePrimaryExpression (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2906:20)
    at parseLeftHandSideExpressionAllowCall (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:2990:61)
    at parsePostfixExpression (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/esprima-fb/esprima.js:3030:20)
From previous event:
    at buildP (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:167:16)
    at ModuleReader.processOutputP (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:221:16)
    at ModuleReader.buildModuleP (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:132:23)
    at ModuleReader.wrapper [as buildModuleP] (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/util.js:53:31)
    at /home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:126:27
From previous event:
    at ModuleReader.<anonymous> (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:97:38)
    at ModuleReader.wrapper [as readModuleP] (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/util.js:53:31)
    at Array.map (<anonymous>)
    at /home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/reader.js:231:32
From previous event:
    at rebuild (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/commoner.js:135:14)
    at processTicksAndRejections (node:internal/process/task_queues:75:11)
From previous event:
    at cliBuildP (/home/stephane/WebstormProjects/pouchdb-fauxton-base/node_modules/commoner/lib/commoner.js:307:7)
Warning: Command failed: node ./node_modules/react-tools/bin/jsx -x jsx app/addons/ app/addons/ --no-cache-dir
built Module("activetasks/tests/activetasks.componentsSpec.react")
built Module("auth/components.react")
built Module("auth/test/auth.componentsSpec.react")
built Module("cluster/cluster.react")

```
I "fixed" it by deleting the app addong test folder.

then I have an ultime issue:
```
Running "less:compile" (less) task
>> assets/less/fauxton.less: [L170:C12] Unrecognised input
Warning: Error compiling assets/less/fauxton.less Use --force to continue.

Aborted due to warnings.
npm ERR! code 6

```

In the gruntfile I have added force
 less: {
            compile: {
                options: {
                    paths: assets.less.paths,
                    force: true
                },
but this does not seems to enable the force flag..
I have no experience in grunt.

so I went to the less files and fixed the issues found (invalid characters)

new less issue:
```
Running "less:compile" (less) task
>> assets/less/bootstrap/bootstrap.less: [L29:C0] '/font-awesome/font-awesome.less' wasn't found. Tried - /font-awesome/font-awesome.less,assets/less/font-awesome/font-awesome.less,app/addons/components/assets/less/font-awesome/font-awesome.less,app/addons/databases/assets/less/font-awesome/font-awesome.less,app/addons/documents/assets/less/font-awesome/font-awesome.less,app/addons/activetasks/assets/less/font-awesome/font-awesome.less,app/addons/config/assets/less/font-awesome/font-awesome.less,app/addons/replication/assets/less/font-awesome/font-awesome.less,app/addons/cors/assets/less/font-awesome/font-awesome.less,app/addons/permissions/assets/less/font-awesome/font-awesome.less,app/addons/compaction/assets/less/font-awesome/font-awesome.less,app/addons/auth/assets/less/font-awesome/font-awesome.less,app/addons/verifyinstall/assets/less/font-awesome/font-awesome.less
Warning: Error compiling assets/less/fauxton.less Use --force to continue.
```

hmm there is many annoying less errors and downgrading to the oldest allowed less version do not remove them all, and I can't use the same version than the original one because of grunt dependency.

hmm so I downgraded to the original grunt versions and now there are no less errors.
jshint fail so I removed all jshint tasks (optional passe anyway?)

**AND MIRACULOUSLY, THE PROJECT BUILD**
> Done, without errors.

then I build fauxton-logic and fauxton-chrome without issues, enabling me to load the resuting extension in chrome.
then on my project which use PouchDB the extension says:
To use the current page with PouchDB-Fauxton, window.PouchDB needs to be set.

so I did 
const localPouch = new PouchDB("dbName");
// @ts-ignore
window.PouchDB = localPouch;

now the extension show its UI!
unfortunately no database are shown
![image](https://user-images.githubusercontent.com/12934716/141180154-396f7fd3-6e1f-418f-bdcd-62c326dc8a71.png)

is that setting correct?
![image](https://user-images.githubusercontent.com/12934716/141180469-8c2e7294-0e64-4c4a-b678-b982cad7f0e9.png)

my bad, the correct fix was:
window.PouchDB = PouchDB;

OMG IT WORKS WELL!

![image](https://user-images.githubusercontent.com/12934716/141181481-77e6935e-5af5-4b81-a8cc-d14f1a638362.png)

I will publish a separate PR fixing the fauxton-base build later.
